### PR TITLE
fix(dockerfile): migrate ARG GH_TOKEN to BuildKit --mount=type=secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BUILD_IMAGE=node:20-bullseye
@@ -12,9 +13,8 @@ COPY ./src ./src
 COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
 
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
 RUN npm run build
 
 FROM ${BUILD_IMAGE} AS dep-resolver
@@ -23,8 +23,7 @@ LABEL stage=pre-prod
 
 COPY package*.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
-RUN npm ci --omit=dev --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --omit=dev --ignore-scripts
 
 FROM ${RUN_IMAGE} AS run-env
 USER nonroot


### PR DESCRIPTION
## Problem

The Dockerfile uses `ARG GH_TOKEN` to pass the GitHub Packages auth token into `npm ci`. Build args are stored in the image layer history, which exposes the token.

The workflow already passes the token via BuildKit `secrets:` but the Dockerfile was not mounting it - so `npm ci` received no token and authentication against `npm.pkg.github.com` failed.

## Changes

- Add `# syntax=docker/dockerfile:1` header to enable BuildKit syntax
- Remove `ARG GH_TOKEN` from both build stages
- Prefix each `npm ci` call with `--mount=type=secret,id=GH_TOKEN,env=GH_TOKEN`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build security by implementing secret mounts for credential handling during builds, replacing direct argument injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->