### PR TITLE
fix: migrated the publishing_status update logic from NATS handler to REST API endpoint

### DIFF
--- a/docs/nats-to-api-migration.md
+++ b/docs/nats-to-api-migration.md
@@ -1,0 +1,88 @@
+# NATS to REST API Migration: Config-Notify Cache Update
+
+## Background
+
+The `ConfigNotifyService` previously listened on a NATS JetStream consumer (`dems.notify`) to receive notifications when a config record changed. On each message, it fetched the config from the database and refreshed the Redis cache entry.
+
+This approach had a hidden coupling: the `event-monitoring-service` had to be connected to NATS as a consumer solely for this one responsibility, and the upstream publisher had to know which stream to target.
+
+## What Changed
+
+The NATS-based cache update has been replaced with a REST API endpoint. The frontend (or any authorized caller) now explicitly triggers a cache refresh by calling the new endpoint with the config ID and the desired publishing status.
+
+### Removed
+
+- `NatsService` dependency from `ConfigNotifyService`
+- `handleNatsMessage` private method
+- `normalizeNatsMessage` static helper method
+- `consumerStream` config property
+- NATS consumer registration in `onModuleInit`
+- `NatsModule` import from `ConfigNotifyModule`
+
+### Added
+
+| File                                            | Purpose                                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------------------- |
+| `src/enums/publishingStatus.enum.ts`            | Enum constraining valid `publishing_status` values (`active`, `inactive`) |
+| `src/config-notify/update-cache.dto.ts`         | Request body DTO with `class-validator` enforcement                       |
+| `src/config-notify/config-notify.controller.ts` | New controller exposing the `PATCH /config-notify/:id` endpoint           |
+| `ConfigNotifyService.updateCache()`             | New public method encapsulating the DB query + cache write                |
+
+### What stayed the same
+
+- On startup, `onModuleInit` still preloads all `active` configs into Redis.
+- `setCache()` is unchanged — it writes the full config object (schema, mapping, functions, related_transaction, publishing_status) to Redis under the `endpointPath` key.
+
+## New API
+
+### `PATCH /config-notify/:id`
+
+Updates the Redis cache entry for a specific config record.
+
+**Auth:** Requires a valid JWT with the `dems:write` claim (`TazamaAuthGuard`).
+
+**Path param:**
+
+| Param | Type    | Description                            |
+| ----- | ------- | -------------------------------------- |
+| `id`  | integer | Primary key of the `tcs_config` record |
+
+**Request body:**
+
+```json
+{
+  "publishing_status": "active"
+}
+```
+
+| Field               | Type   | Allowed values             |
+| ------------------- | ------ | -------------------------- |
+| `publishing_status` | string | `"active"` or `"inactive"` |
+
+Any other value returns `400 Bad Request` with a descriptive message.
+
+**Success response — `200 OK`:**
+
+```json
+{
+  "message": "Cache updated successfully for config ID: 1"
+}
+```
+
+**Error responses:**
+
+| Status             | Reason                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| `400 Bad Request`  | `id` is not a valid integer, or `publishing_status` is not `"active"` / `"inactive"` |
+| `401 Unauthorized` | Missing or invalid JWT                                                               |
+| `403 Forbidden`    | JWT is valid but lacks the `dems:write` claim                                        |
+| `404 Not Found`    | No `tcs_config` record exists for the given `id`                                     |
+
+## How the cache update works
+
+1. Controller receives `id` (path param) and `publishing_status` (body).
+2. `ConfigNotifyService.updateCache()` queries `tcs_config` for all fields by `id`.
+3. The `publishing_status` on the fetched record is overridden with the value from the request.
+4. `setCache()` writes the full config object to Redis under the `endpointPath` key.
+
+This means the schema, mapping, functions, and related_transaction always reflect what is currently in the database, while `publishing_status` reflects exactly what the caller requested.

--- a/src/config-notify/config-notify.controller.ts
+++ b/src/config-notify/config-notify.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Patch, Param, Body, ParseIntPipe, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
+import { ConfigNotifyService } from './config-notify.service';
+import { UpdateCacheDto } from './update-cache.dto';
+import { TazamaAuthGuard } from '../auth/tazama-auth.guard';
+import { RequireDemsWriteRole } from '../auth/auth.decorator';
+
+@Controller('config-notify')
+@UseGuards(TazamaAuthGuard)
+export class ConfigNotifyController {
+  constructor(private readonly configNotifyService: ConfigNotifyService) {}
+
+  @Patch(':id')
+  @RequireDemsWriteRole()
+  @HttpCode(HttpStatus.OK)
+  async updateCache(@Param('id', ParseIntPipe) id: number, @Body() body: UpdateCacheDto): Promise<{ message: string }> {
+    await this.configNotifyService.updateCache(id, body.publishing_status);
+    return { message: `Cache updated successfully for config ID: ${id}` };
+  }
+}

--- a/src/config-notify/config-notify.module.ts
+++ b/src/config-notify/config-notify.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigNotifyService } from './config-notify.service';
+import { ConfigNotifyController } from './config-notify.controller';
 import { LoggerModule } from '../logger-service/logger-service.module';
 import { ConfigModule } from '@nestjs/config';
 import { RedisModule } from '../redis/redis.module';
-import { NatsModule } from '../nats/nats.module';
 
 @Module({
-  imports: [LoggerModule, ConfigModule, RedisModule, NatsModule],
-  controllers: [],
+  imports: [LoggerModule, ConfigModule, RedisModule],
+  controllers: [ConfigNotifyController],
   providers: [ConfigNotifyService],
 })
 export class ConfigNotifyModule {}

--- a/src/config-notify/config-notify.service.ts
+++ b/src/config-notify/config-notify.service.ts
@@ -1,37 +1,28 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, NotFoundException, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { LoggerService, RedisService } from '@tazama-lf/frms-coe-lib';
 import { DatabaseService } from '../database/database.service';
-import { NatsService } from '../nats/nats.service';
-import { NatsMessage } from '../interfaces/iNatsMessage';
 import { CacheData } from '../interfaces/iCacheData';
+import { PublishingStatus } from '../enums/publishingStatus.enum';
 
 @Injectable()
 export class ConfigNotifyService implements OnModuleInit {
   private static readonly DEFAULT_CACHE_TTL = 3600;
   private readonly cacheTtl: number;
-  private readonly consumerStream: string;
 
   constructor(
     private readonly loggerService: LoggerService,
     private readonly redisService: RedisService,
     private readonly configService: ConfigService,
     private readonly databaseService: DatabaseService,
-    private readonly natsService: NatsService,
   ) {
     this.cacheTtl = this.configService.get<number>('cache.timeToLive', ConfigNotifyService.DEFAULT_CACHE_TTL);
-    this.consumerStream = this.configService.get<string>('nats.consumerStream', 'dems.notify');
   }
 
   private readonly LOG_CONTEXT = ConfigNotifyService.name;
 
   async onModuleInit(): Promise<void> {
     try {
-      // Register consumer without producer stream since we only consume messages
-      await this.natsService.registerConsumer([this.consumerStream], this.handleNatsMessage.bind(this));
-
-      this.loggerService.log(`NATS consumer registered for ${this.consumerStream}`, this.LOG_CONTEXT);
-
       const result = await this.databaseService.query<CacheData>(
         'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status FROM tcs_config where publishing_status = \'active\' ',
       );
@@ -50,57 +41,20 @@ export class ConfigNotifyService implements OnModuleInit {
     }
   }
 
-  private async handleNatsMessage(reqObj: unknown): Promise<void> {
-    try {
-      const message = ConfigNotifyService.normalizeNatsMessage(reqObj);
-      if (!message) {
-        this.loggerService.error('Invalid NATS message: expected JSON with non-empty transactionID', this.LOG_CONTEXT);
-        return;
-      }
-      this.loggerService.log(`Received NATS message for config id: ${message.transactionID}`, this.LOG_CONTEXT);
+  public async updateCache(id: number, publishingStatus: PublishingStatus): Promise<void> {
+    const result = await this.databaseService.query<CacheData>(
+      'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status FROM tcs_config WHERE id = $1',
+      [id],
+    );
 
-      const result = await this.databaseService.query<CacheData>(
-        'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status FROM tcs_config WHERE id = $1',
-        [message.transactionID],
-      );
-
-      if (result.rows.length) {
-        const [config] = result.rows;
-        await this.setCache(config);
-        this.loggerService.log(
-          `Updated cache for key: ${config.endpointPath} --> publishing status: ${config.publishing_status}`,
-          this.LOG_CONTEXT,
-        );
-        this.loggerService.log(`Successfully processed transaction: ${message.transactionID}`, this.LOG_CONTEXT);
-      } else {
-        this.loggerService.warn(`Config not found for ID: ${message.transactionID}`, this.LOG_CONTEXT);
-      }
-    } catch (error) {
-      this.loggerService.error('Error processing message', error, this.LOG_CONTEXT);
-    }
-  }
-
-  private static normalizeNatsMessage(input: unknown): NatsMessage | null {
-    let obj: unknown = input;
-
-    if (typeof input === 'string') {
-      try {
-        obj = JSON.parse(input);
-      } catch {
-        return null;
-      }
-    } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(input)) {
-      try {
-        obj = JSON.parse(input.toString('utf8'));
-      } catch {
-        return null;
-      }
+    if (!result.rows.length) {
+      throw new NotFoundException(`Config not found for ID: ${id}`);
     }
 
-    if (!obj || typeof obj !== 'object') return null;
-    const { transactionID } = obj as { transactionID?: unknown };
-    if (typeof transactionID !== 'string' || transactionID.trim() === '') return null;
-    return { transactionID: transactionID.trim() };
+    const [config] = result.rows;
+    config.publishing_status = publishingStatus;
+    await this.setCache(config);
+    this.loggerService.log(`Updated cache for key: ${config.endpointPath} --> publishing status: ${publishingStatus}`, this.LOG_CONTEXT);
   }
 
   public async setCache(config: CacheData): Promise<void> {

--- a/src/config-notify/update-cache.dto.ts
+++ b/src/config-notify/update-cache.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum } from 'class-validator';
+import { PublishingStatus } from '../enums/publishingStatus.enum';
+
+export class UpdateCacheDto {
+  @IsEnum(PublishingStatus, {
+    message: 'publishing_status must be either "active" or "inactive"',
+  })
+  publishing_status!: PublishingStatus;
+}

--- a/src/enums/publishingStatus.enum.ts
+++ b/src/enums/publishingStatus.enum.ts
@@ -1,0 +1,4 @@
+export enum PublishingStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}

--- a/tests/config-notify/config-notify.controller.spec.ts
+++ b/tests/config-notify/config-notify.controller.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ConfigNotifyController } from '../../src/config-notify/config-notify.controller';
+import { ConfigNotifyService } from '../../src/config-notify/config-notify.service';
+import { TazamaAuthGuard } from '../../src/auth/tazama-auth.guard';
+import { PublishingStatus } from '../../src/enums/publishingStatus.enum';
+import { UpdateCacheDto } from '../../src/config-notify/update-cache.dto';
+
+describe('ConfigNotifyController', () => {
+  let controller: ConfigNotifyController;
+  let mockService: jest.Mocked<ConfigNotifyService>;
+
+  beforeEach(async () => {
+    mockService = {
+      updateCache: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfigNotifyController],
+      providers: [{ provide: ConfigNotifyService, useValue: mockService }],
+    })
+      .overrideGuard(TazamaAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
+
+    controller = module.get<ConfigNotifyController>(ConfigNotifyController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('PATCH /config-notify/:id', () => {
+    const makeBody = (status: PublishingStatus): UpdateCacheDto => {
+      const dto = new UpdateCacheDto();
+      dto.publishing_status = status;
+      return dto;
+    };
+
+    it('should call service.updateCache with the parsed id and publishing_status', async () => {
+      mockService.updateCache.mockResolvedValue(undefined);
+
+      const result = await controller.updateCache(1, makeBody(PublishingStatus.ACTIVE));
+
+      expect(mockService.updateCache).toHaveBeenCalledWith(1, PublishingStatus.ACTIVE);
+      expect(result).toEqual({ message: 'Cache updated successfully for config ID: 1' });
+    });
+
+    it('should work for inactive publishing_status', async () => {
+      mockService.updateCache.mockResolvedValue(undefined);
+
+      const result = await controller.updateCache(42, makeBody(PublishingStatus.INACTIVE));
+
+      expect(mockService.updateCache).toHaveBeenCalledWith(42, PublishingStatus.INACTIVE);
+      expect(result).toEqual({ message: 'Cache updated successfully for config ID: 42' });
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      mockService.updateCache.mockRejectedValue(new NotFoundException('Config not found for ID: 99'));
+
+      await expect(controller.updateCache(99, makeBody(PublishingStatus.ACTIVE))).rejects.toThrow(
+        new NotFoundException('Config not found for ID: 99'),
+      );
+    });
+
+    it('should propagate unexpected service errors', async () => {
+      mockService.updateCache.mockRejectedValue(new Error('Unexpected DB failure'));
+
+      await expect(controller.updateCache(1, makeBody(PublishingStatus.ACTIVE))).rejects.toThrow('Unexpected DB failure');
+    });
+  });
+});

--- a/tests/config-notify/config-notify.service.spec.ts
+++ b/tests/config-notify/config-notify.service.spec.ts
@@ -1,16 +1,36 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { LoggerService, RedisService } from '@tazama-lf/frms-coe-lib';
 import { ConfigNotifyService } from '../../src/config-notify/config-notify.service';
 import { DatabaseService } from '../../src/database/database.service';
-import { NatsService } from '../../src/nats/nats.service';
+import { PublishingStatus } from '../../src/enums/publishingStatus.enum';
+
+const CACHE_TTL = 86400;
+
+const makeDbRow = (overrides = {}) => ({
+  endpointPath: '/test/endpoint',
+  schema: { type: 'object' },
+  mapping: { field: 'value' },
+  functions: { fn: 'test' },
+  related_transaction: 'rel-tx-id',
+  publishing_status: 'active',
+  ...overrides,
+});
+
+const makeQueryResult = (rows: object[]) => ({
+  rows,
+  rowCount: rows.length,
+  command: 'SELECT',
+  oid: 0,
+  fields: [],
+});
 
 describe('ConfigNotifyService', () => {
   let service: ConfigNotifyService;
   let mockLogger: jest.Mocked<LoggerService>;
   let mockRedis: jest.Mocked<RedisService>;
   let mockDatabaseService: jest.Mocked<DatabaseService>;
-  let mockNatsService: jest.Mocked<NatsService>;
 
   beforeEach(async () => {
     mockLogger = {
@@ -27,10 +47,6 @@ describe('ConfigNotifyService', () => {
       query: jest.fn(),
     } as any;
 
-    mockNatsService = {
-      registerConsumer: jest.fn(),
-    } as any;
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ConfigNotifyService,
@@ -39,176 +55,142 @@ describe('ConfigNotifyService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn((key, defaultValue) => {
-              if (key === 'cache.timeToLive') return 86400;
-              if (key === 'nats.consumerStream') return 'config.notification';
-              if (key === 'PRODUCER_STREAM') return 'dems.notification.response';
+            get: jest.fn((key: string, defaultValue: unknown) => {
+              if (key === 'cache.timeToLive') return CACHE_TTL;
               return defaultValue;
             }),
           },
         },
         { provide: DatabaseService, useValue: mockDatabaseService },
-        { provide: NatsService, useValue: mockNatsService },
       ],
     }).compile();
 
     service = module.get<ConfigNotifyService>(ConfigNotifyService);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
+  // ---------------------------------------------------------------------------
   describe('onModuleInit', () => {
-    it('should register consumer and preload cache', async () => {
-      mockDatabaseService.query.mockResolvedValue({
-        rows: [{ endpointPath: '/test', schema: {}, mapping: {}, functions: {}, publishing_status: 'active' }],
-        rowCount: 1,
-        command: 'SELECT',
-        oid: 0,
-        fields: [],
-      });
+    it('should preload all active configs into cache on startup', async () => {
+      const rows = [makeDbRow({ endpointPath: '/a' }), makeDbRow({ endpointPath: '/b' })];
+      mockDatabaseService.query.mockResolvedValue(makeQueryResult(rows));
 
       await service.onModuleInit();
 
-      expect(mockNatsService.registerConsumer).toHaveBeenCalled();
-      expect(mockRedis.setJson).toHaveBeenCalled();
-      expect(mockLogger.log).toHaveBeenCalledWith('NATS consumer registered for config.notification', 'ConfigNotifyService');
+      expect(mockDatabaseService.query).toHaveBeenCalledTimes(1);
+      expect(mockRedis.setJson).toHaveBeenCalledTimes(2);
+      expect(mockLogger.log).toHaveBeenCalledWith('Cache preloaded: 2 configurations', 'ConfigNotifyService');
     });
 
-    it('should throw error on failure', async () => {
-      mockNatsService.registerConsumer.mockRejectedValue(new Error('Connection failed'));
+    it('should preload nothing when no active configs exist', async () => {
+      mockDatabaseService.query.mockResolvedValue(makeQueryResult([]));
 
-      await expect(service.onModuleInit()).rejects.toThrow('Connection failed');
-    });
-  });
+      await service.onModuleInit();
 
-  describe('handleNatsMessage', () => {
-    it('should update cache when config found', async () => {
-      const message = { transactionID: '123' };
-      mockDatabaseService.query.mockResolvedValue({
-        rows: [{ endpointPath: '/test', schema: {}, mapping: {}, functions: {}, publishing_status: 'active' }],
-        rowCount: 1,
-        command: 'SELECT',
-        oid: 0,
-        fields: [],
-      });
-
-      await (service as any).handleNatsMessage(message);
-
-      expect(mockRedis.setJson).toHaveBeenCalled();
-      expect(mockLogger.log).toHaveBeenCalledWith('Updated cache for key: /test --> publishing status: active', 'ConfigNotifyService');
+      expect(mockRedis.setJson).not.toHaveBeenCalled();
+      expect(mockLogger.log).toHaveBeenCalledWith('Cache preloaded: 0 configurations', 'ConfigNotifyService');
     });
 
-    it('should log warning when config not found', async () => {
-      const message = { transactionID: '456' };
-      mockDatabaseService.query.mockResolvedValue({
-        rows: [],
-        rowCount: 0,
-        command: 'SELECT',
-        oid: 0,
-        fields: [],
-      });
-
-      await (service as any).handleNatsMessage(message);
-
-      expect(mockLogger.warn).toHaveBeenCalledWith('Config not found for ID: 456', 'ConfigNotifyService');
-    });
-
-    it('should log error for invalid message', async () => {
-      await (service as any).handleNatsMessage(null);
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Invalid NATS message: expected JSON with non-empty transactionID',
-        'ConfigNotifyService',
-      );
-    });
-
-    it('should log error for missing transactionID', async () => {
-      await (service as any).handleNatsMessage({});
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Invalid NATS message: expected JSON with non-empty transactionID',
-        'ConfigNotifyService',
-      );
-    });
-
-    it('should log error on database error', async () => {
-      const message = { transactionID: '789' };
-      const dbError = new Error('DB error');
+    it('should log and rethrow when the DB query fails', async () => {
+      const dbError = new Error('DB connection lost');
       mockDatabaseService.query.mockRejectedValue(dbError);
 
-      await (service as any).handleNatsMessage(message);
-
-      expect(mockLogger.error).toHaveBeenCalledWith('Error processing message', dbError, 'ConfigNotifyService');
-    });
-
-    it('should handle string JSON payload', async () => {
-      const stringMessage = JSON.stringify({ transactionID: '999' });
-      mockDatabaseService.query.mockResolvedValue({
-        rows: [{ endpointPath: '/test', schema: {}, mapping: {}, functions: {}, publishing_status: 'active' }],
-        rowCount: 1,
-        command: 'SELECT',
-        oid: 0,
-        fields: [],
-      });
-
-      await (service as any).handleNatsMessage(stringMessage);
-
-      expect(mockRedis.setJson).toHaveBeenCalled();
-      expect(mockLogger.log).toHaveBeenCalledWith('Received NATS message for config id: 999', 'ConfigNotifyService');
-    });
-
-    it('should handle Buffer payload', async () => {
-      const bufferMessage = Buffer.from(JSON.stringify({ transactionID: '888' }), 'utf8');
-      mockDatabaseService.query.mockResolvedValue({
-        rows: [{ endpointPath: '/test', schema: {}, mapping: {}, functions: {}, publishing_status: 'active' }],
-        rowCount: 1,
-        command: 'SELECT',
-        oid: 0,
-        fields: [],
-      });
-
-      await (service as any).handleNatsMessage(bufferMessage);
-
-      expect(mockRedis.setJson).toHaveBeenCalled();
-      expect(mockLogger.log).toHaveBeenCalledWith('Received NATS message for config id: 888', 'ConfigNotifyService');
-    });
-
-    it('should reject invalid JSON string', async () => {
-      await (service as any).handleNatsMessage('invalid json');
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Invalid NATS message: expected JSON with non-empty transactionID',
-        'ConfigNotifyService',
-      );
+      await expect(service.onModuleInit()).rejects.toThrow('DB connection lost');
+      expect(mockLogger.error).toHaveBeenCalledWith(`Failed to initialize ConfigNotifyService: ${String(dbError)}`, 'ConfigNotifyService');
     });
   });
 
-  describe('setCache', () => {
-    it('should store config in Redis', async () => {
-      const config = {
-        endpointPath: '/test',
-        schema: { type: 'object' },
-        mapping: { field: 'value' },
-        functions: { fn: 'test' },
-        related_transaction: '',
-        publishing_status: 'active',
-      };
+  // ---------------------------------------------------------------------------
+  describe('updateCache', () => {
+    it('should fetch config by id, override publishing_status, and write to cache', async () => {
+      const row = makeDbRow({ publishing_status: 'inactive' });
+      mockDatabaseService.query.mockResolvedValue(makeQueryResult([row]));
 
-      await service.setCache(config);
+      await service.updateCache(1, PublishingStatus.ACTIVE);
+
+      expect(mockDatabaseService.query).toHaveBeenCalledWith(expect.stringContaining('WHERE id = $1'), [1]);
+      // The publishing_status stored in Redis must reflect what was passed in, not what was in the DB
+      expect(mockRedis.setJson).toHaveBeenCalledWith(
+        row.endpointPath,
+        JSON.stringify({
+          schema: row.schema,
+          mapping: row.mapping,
+          functions: row.functions,
+          related_transaction: row.related_transaction,
+          publishing_status: PublishingStatus.ACTIVE,
+        }),
+        CACHE_TTL,
+      );
+    });
+
+    it('should set publishing_status to inactive when requested', async () => {
+      const row = makeDbRow({ publishing_status: 'active' });
+      mockDatabaseService.query.mockResolvedValue(makeQueryResult([row]));
+
+      await service.updateCache(5, PublishingStatus.INACTIVE);
+
+      const [, storedJson] = mockRedis.setJson.mock.calls[0];
+      expect(JSON.parse(storedJson as string).publishing_status).toBe(PublishingStatus.INACTIVE);
+    });
+
+    it('should log the update after writing to cache', async () => {
+      const row = makeDbRow();
+      mockDatabaseService.query.mockResolvedValue(makeQueryResult([row]));
+
+      await service.updateCache(1, PublishingStatus.ACTIVE);
+
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        `Updated cache for key: ${row.endpointPath} --> publishing status: ${PublishingStatus.ACTIVE}`,
+        'ConfigNotifyService',
+      );
+    });
+
+    it('should throw NotFoundException when no config matches the given id', async () => {
+      mockDatabaseService.query.mockResolvedValue(makeQueryResult([]));
+
+      await expect(service.updateCache(99, PublishingStatus.ACTIVE)).rejects.toThrow(new NotFoundException('Config not found for ID: 99'));
+      expect(mockRedis.setJson).not.toHaveBeenCalled();
+    });
+
+    it('should propagate DB errors', async () => {
+      mockDatabaseService.query.mockRejectedValue(new Error('Query failed'));
+
+      await expect(service.updateCache(1, PublishingStatus.ACTIVE)).rejects.toThrow('Query failed');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('setCache', () => {
+    it('should serialise all config fields and store in Redis under the endpointPath key', async () => {
+      const config = makeDbRow();
+
+      await service.setCache(config as any);
 
       expect(mockRedis.setJson).toHaveBeenCalledWith(
-        '/test',
+        config.endpointPath,
         JSON.stringify({
-          schema: { type: 'object' },
-          mapping: { field: 'value' },
-          functions: { fn: 'test' },
-          related_transaction: '',
-          publishing_status: 'active',
+          schema: config.schema,
+          mapping: config.mapping,
+          functions: config.functions,
+          related_transaction: config.related_transaction,
+          publishing_status: config.publishing_status,
         }),
-        86400,
+        CACHE_TTL,
       );
+    });
+
+    it('should use the configured TTL from ConfigService', async () => {
+      await service.setCache(makeDbRow() as any);
+
+      const [, , ttl] = mockRedis.setJson.mock.calls[0];
+      expect(ttl).toBe(CACHE_TTL);
     });
   });
 });


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Replaced a NATS JetStream consumer in `ConfigNotifyService` with a REST `PATCH /config-notify/:id` endpoint. Concretely:

- **Removed** `handleNatsMessage`, `normalizeNatsMessage`, `NatsService` injection, `consumerStream` config, and `NatsModule` from the module.
- **Added** `ConfigNotifyController` with a single `PATCH /:id` route guarded by `TazamaAuthGuard` + `dems:write` claim.
- **Added** `UpdateCacheDto` using `@IsEnum(PublishingStatus)` to enforce that `publishing_status` is strictly `"active"` or `"inactive"` at the deserialization boundary — anything else returns a `400` before it reaches the service.
- **Added** `PublishingStatus` enum as the single source of truth for allowed values.

- **Rewrote** the service unit tests to reflect the new contract and added a dedicated controller spec.

`onModuleInit` cache preloading on startup is unchanged.

---

## Why are we doing this?

NATS is not the correct way when a NON-CORE service wants to talk to a CORE service. Also, for it to work, we had to modify the FRMSmessage interface in proto. Adding service level fields to FRMSmessage was not the right design decision. 

The NATS approach pushed **cache invalidation control into an event stream** that the frontend had no visibility into. That created three real problems:

1. **Tight invisible coupling.** The admin frontend couldn't directly trigger a cache refresh — it had to rely on a separate upstream publisher sending a message to the right NATS stream with the right payload format. Any mismatch silently did nothing.

2. **No feedback loop.** NATS fire-and-forget meant the caller never knew if the cache was actually updated, if the config ID existed, or if the payload was malformed. Errors were buried in service logs. An HTTP endpoint gives the caller an immediate, typed response — `200`, `400`, `404` — closing that loop.

3. **Wrong tool for an intentional action.** NATS is the right choice for high-throughput, decoupled event propagation. A user deliberately toggling a config's publishing status is a command — it has a subject, a known target, and expects confirmation. That's HTTP's domain, not a message bus.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated endpoint to update configuration publishing status via API requests.
  * Publishing status can be set to active or inactive with input validation.
  * Returns appropriate HTTP error codes for invalid requests and missing configurations.

* **Documentation**
  * Added migration guide documenting the updated configuration notification workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/event-monitoring-service/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->