### PR TITLE
fix: DEMS stopped sending transactions to ED - the fix was missing NATS logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7126,6 +7126,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/src/config-notify/config-notify.module.ts
+++ b/src/config-notify/config-notify.module.ts
@@ -4,9 +4,10 @@ import { ConfigNotifyController } from './config-notify.controller';
 import { LoggerModule } from '../logger-service/logger-service.module';
 import { ConfigModule } from '@nestjs/config';
 import { RedisModule } from '../redis/redis.module';
+import { NatsModule } from '../nats/nats.module';
 
 @Module({
-  imports: [LoggerModule, ConfigModule, RedisModule],
+  imports: [LoggerModule, ConfigModule, RedisModule, NatsModule],
   controllers: [ConfigNotifyController],
   providers: [ConfigNotifyService],
 })

--- a/src/config-notify/config-notify.service.ts
+++ b/src/config-notify/config-notify.service.ts
@@ -4,24 +4,33 @@ import { LoggerService, RedisService } from '@tazama-lf/frms-coe-lib';
 import { DatabaseService } from '../database/database.service';
 import { CacheData } from '../interfaces/iCacheData';
 import { PublishingStatus } from '../enums/publishingStatus.enum';
+import { NatsService } from '../nats/nats.service';
+import { NatsMessage } from '../interfaces/iNatsMessage';
 
 @Injectable()
 export class ConfigNotifyService implements OnModuleInit {
   private static readonly DEFAULT_CACHE_TTL = 3600;
   private readonly cacheTtl: number;
+  private readonly consumerStream: string;
 
   constructor(
     private readonly loggerService: LoggerService,
     private readonly redisService: RedisService,
     private readonly configService: ConfigService,
     private readonly databaseService: DatabaseService,
+    private readonly natsService: NatsService,
   ) {
     this.cacheTtl = this.configService.get<number>('cache.timeToLive', ConfigNotifyService.DEFAULT_CACHE_TTL);
+    this.consumerStream = this.configService.get<string>('nats.consumerStream', 'event-director');
   }
 
   private readonly LOG_CONTEXT = ConfigNotifyService.name;
 
   async onModuleInit(): Promise<void> {
+    // Register consumer without producer stream since we only consume messages
+    this.natsService.registerConsumer([this.consumerStream], this.handleNatsMessage.bind(this));
+
+    this.loggerService.log(`NATS consumer registered for ${this.consumerStream}`, this.LOG_CONTEXT);
     try {
       const result = await this.databaseService.query<CacheData>(
         'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status FROM tcs_config where publishing_status = \'active\' ',
@@ -67,5 +76,9 @@ export class ConfigNotifyService implements OnModuleInit {
       publishing_status: config.publishing_status,
     };
     await this.redisService.setJson(key, JSON.stringify(data), this.cacheTtl);
+  }
+
+  private handleNatsMessage(message: NatsMessage): void {
+    this.loggerService.log(`Received NATS message: ${JSON.stringify(message)}`, this.LOG_CONTEXT);
   }
 }

--- a/src/config-notify/config-notify.service.ts
+++ b/src/config-notify/config-notify.service.ts
@@ -5,7 +5,6 @@ import { DatabaseService } from '../database/database.service';
 import { CacheData } from '../interfaces/iCacheData';
 import { PublishingStatus } from '../enums/publishingStatus.enum';
 import { NatsService } from '../nats/nats.service';
-import { NatsMessage } from '../interfaces/iNatsMessage';
 
 @Injectable()
 export class ConfigNotifyService implements OnModuleInit {
@@ -27,8 +26,7 @@ export class ConfigNotifyService implements OnModuleInit {
   private readonly LOG_CONTEXT = ConfigNotifyService.name;
 
   async onModuleInit(): Promise<void> {
-    // Register consumer without producer stream since we only consume messages
-    this.natsService.registerConsumer([this.consumerStream], this.handleNatsMessage.bind(this));
+    await this.natsService.registerConsumer([this.consumerStream], this.handleNatsMessage.bind(this));
 
     this.loggerService.log(`NATS consumer registered for ${this.consumerStream}`, this.LOG_CONTEXT);
     try {
@@ -78,7 +76,7 @@ export class ConfigNotifyService implements OnModuleInit {
     await this.redisService.setJson(key, JSON.stringify(data), this.cacheTtl);
   }
 
-  private handleNatsMessage(message: NatsMessage): void {
+  private handleNatsMessage(message: unknown): void {
     this.loggerService.log(`Received NATS message: ${JSON.stringify(message)}`, this.LOG_CONTEXT);
   }
 }

--- a/tests/config-notify/config-notify.service.spec.ts
+++ b/tests/config-notify/config-notify.service.spec.ts
@@ -5,6 +5,7 @@ import { LoggerService, RedisService } from '@tazama-lf/frms-coe-lib';
 import { ConfigNotifyService } from '../../src/config-notify/config-notify.service';
 import { DatabaseService } from '../../src/database/database.service';
 import { PublishingStatus } from '../../src/enums/publishingStatus.enum';
+import { NatsService } from '../../src/nats/nats.service';
 
 const CACHE_TTL = 86400;
 
@@ -31,7 +32,7 @@ describe('ConfigNotifyService', () => {
   let mockLogger: jest.Mocked<LoggerService>;
   let mockRedis: jest.Mocked<RedisService>;
   let mockDatabaseService: jest.Mocked<DatabaseService>;
-
+  let mockNatsService: jest.Mocked<NatsService>;
   beforeEach(async () => {
     mockLogger = {
       log: jest.fn(),
@@ -41,6 +42,10 @@ describe('ConfigNotifyService', () => {
 
     mockRedis = {
       setJson: jest.fn(),
+    } as any;
+
+    mockNatsService = {
+      registerConsumer: jest.fn(),
     } as any;
 
     mockDatabaseService = {
@@ -57,11 +62,14 @@ describe('ConfigNotifyService', () => {
           useValue: {
             get: jest.fn((key: string, defaultValue: unknown) => {
               if (key === 'cache.timeToLive') return CACHE_TTL;
+              if (key === 'nats.consumerStream') return 'config.notification';
+              if (key === 'PRODUCER_STREAM') return 'dems.notification.response';
               return defaultValue;
             }),
           },
         },
         { provide: DatabaseService, useValue: mockDatabaseService },
+        { provide: NatsService, useValue: mockNatsService },
       ],
     }).compile();
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

In one of the previous PRs (shifting publishing_status UPDATE logic from NATS handler to http API), we accidentally removed the register.consumer() function call as well inside the init.module()

That lead to the NATS init logic being missing. This PR is just a partial revert back to previous work.

## Why are we doing this?

So that DEMS can ingest messages and FORWARD them to ED as per expected behaviour. 

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated a messaging consumer to register and handle incoming messages at runtime.
  * Added runtime logging for received message payloads to aid observability.
  * Updated tests to cover messaging configuration and initialization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->