### PR TITLE
feat: add tenant_id to CacheData interface and update related queries in ConfigNotifyService.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig([
       '@typescript-eslint/restrict-template-expressions': 'error',
       '@typescript-eslint/strict-boolean-expressions': 'off',
       '@typescript-eslint/max-params': ['error', { max: 6 }],
-      '@stylistic/quotes': ['error', 'single'],
+      '@stylistic/quotes': ['error', 'single', {avoidEscape: true}],
       'complexity': ['warn', { max: 15 }],
       'max-depth': ['error', { max: 6 }],
       'no-console': 'error',

--- a/src/config-notify/config-notify.service.ts
+++ b/src/config-notify/config-notify.service.ts
@@ -31,7 +31,7 @@ export class ConfigNotifyService implements OnModuleInit {
     this.loggerService.log(`NATS consumer registered for ${this.consumerStream}`, this.LOG_CONTEXT);
     try {
       const result = await this.databaseService.query<CacheData>(
-        'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status FROM tcs_config where publishing_status = \'active\' ',
+        'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status, tenant_id FROM tcs_config where publishing_status = \'active\' ',
       );
       const configs = result.rows;
 
@@ -50,7 +50,7 @@ export class ConfigNotifyService implements OnModuleInit {
 
   public async updateCache(id: number, publishingStatus: PublishingStatus): Promise<void> {
     const result = await this.databaseService.query<CacheData>(
-      'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status FROM tcs_config WHERE id = $1',
+      'SELECT endpoint_path AS "endpointPath", schema, mapping, functions, related_transaction, publishing_status, tenant_id FROM tcs_config WHERE id = $1',
       [id],
     );
 
@@ -61,11 +61,14 @@ export class ConfigNotifyService implements OnModuleInit {
     const [config] = result.rows;
     config.publishing_status = publishingStatus;
     await this.setCache(config);
-    this.loggerService.log(`Updated cache for key: ${config.endpointPath} --> publishing status: ${publishingStatus}`, this.LOG_CONTEXT);
+    this.loggerService.log(
+      `Updated cache for key: ${config.tenant_id}:${config.endpointPath} --> publishing status: ${publishingStatus}`,
+      this.LOG_CONTEXT,
+    );
   }
 
   public async setCache(config: CacheData): Promise<void> {
-    const key = config.endpointPath;
+    const key = `${config.tenant_id}:${config.endpointPath}`;
     const data = {
       schema: config.schema,
       mapping: config.mapping,

--- a/src/dems-engine/dems-engine.service.ts
+++ b/src/dems-engine/dems-engine.service.ts
@@ -50,11 +50,11 @@ export class DemsEngineService {
   }
 
   @ApmSpan('dems-find-schema-and-mapping')
-  async findSchemaAndMapping(endpoint: string): Promise<FindSchemaAndMappingResult> {
+  async findSchemaAndMapping(endpoint: string, tenantId: string): Promise<FindSchemaAndMappingResult> {
     // latest change here is: it also fetches relatedTransaction now
     this.loggerService.log(`Looking up schema for endpoint: ${endpoint}`);
 
-    const cacheKey = endpoint;
+    const cacheKey = `${tenantId}:${endpoint}`;
     const cachedSchema = await this.redisService.getJson(cacheKey);
 
     if (cachedSchema) {
@@ -68,8 +68,8 @@ export class DemsEngineService {
     // not found in cache, query the database
     this.loggerService.log(`Cache miss for endpoint: ${endpoint}. Querying database...`);
     const result = await this.databaseService.query(
-      'SELECT schema, mapping, functions, related_transaction, publishing_status FROM tcs_config WHERE endpoint_path = $1 and publishing_status = \'active\'',
-      [endpoint],
+      "SELECT schema, mapping, functions, related_transaction, publishing_status FROM tcs_config WHERE endpoint_path = $1 and tenant_id = $2 and publishing_status = 'active'",
+      [endpoint, tenantId],
     );
     const [record] = result.rows;
     if (result.rows.length) {
@@ -443,7 +443,7 @@ export class DemsEngineService {
   async handleMessage(payload: any, endpoint: string, tenantId: string, isPayloadXml: boolean): Promise<ErrorResponse | ProcessingResult> {
     try {
       // refer to /docs/helpers for example schema and mapping configuration
-      const result = await this.findSchemaAndMapping(endpoint);
+      const result = await this.findSchemaAndMapping(endpoint, tenantId);
       if (!result) {
         this.loggerService.warn('Building error response: Schema not found for the specified endpoint', this.LOG_CONTEXT);
         return buildErrorResponse('Schema not found for the specified endpoint', ['No schema exists for this endpoint']);

--- a/src/dems-engine/dems-engine.service.ts
+++ b/src/dems-engine/dems-engine.service.ts
@@ -473,7 +473,7 @@ export class DemsEngineService {
       // this is required as per event-director payload structure
       const enhancedRequest = { ...payload, TenantId: tenantId, TxTp: transactionType };
 
-      const relatedResult = relatedTransaction ? await this.findSchemaAndMapping(relatedTransaction) : null;
+      const relatedResult = relatedTransaction ? await this.findSchemaAndMapping(relatedTransaction, tenantId) : null;
       const [, relatedMapping, ,] = relatedResult ?? [];
 
       // in case of pacs002, the first processMapping will give the DataCache

--- a/src/interfaces/iCacheData.ts
+++ b/src/interfaces/iCacheData.ts
@@ -5,5 +5,6 @@ interface CacheData {
   functions: object;
   related_transaction: string;
   publishing_status: string;
+  tenant_id: string;
 }
 export type { CacheData };

--- a/tests/config-notify/config-notify.service.spec.ts
+++ b/tests/config-notify/config-notify.service.spec.ts
@@ -10,6 +10,7 @@ import { NatsService } from '../../src/nats/nats.service';
 const CACHE_TTL = 86400;
 
 const makeDbRow = (overrides = {}) => ({
+  tenant_id: 'test-tenant',
   endpointPath: '/test/endpoint',
   schema: { type: 'object' },
   mapping: { field: 'value' },
@@ -126,7 +127,7 @@ describe('ConfigNotifyService', () => {
       expect(mockDatabaseService.query).toHaveBeenCalledWith(expect.stringContaining('WHERE id = $1'), [1]);
       // The publishing_status stored in Redis must reflect what was passed in, not what was in the DB
       expect(mockRedis.setJson).toHaveBeenCalledWith(
-        row.endpointPath,
+        `${row.tenant_id}:${row.endpointPath}`,
         JSON.stringify({
           schema: row.schema,
           mapping: row.mapping,
@@ -155,7 +156,7 @@ describe('ConfigNotifyService', () => {
       await service.updateCache(1, PublishingStatus.ACTIVE);
 
       expect(mockLogger.log).toHaveBeenCalledWith(
-        `Updated cache for key: ${row.endpointPath} --> publishing status: ${PublishingStatus.ACTIVE}`,
+        `Updated cache for key: ${row.tenant_id}:${row.endpointPath} --> publishing status: ${PublishingStatus.ACTIVE}`,
         'ConfigNotifyService',
       );
     });
@@ -182,7 +183,7 @@ describe('ConfigNotifyService', () => {
       await service.setCache(config as any);
 
       expect(mockRedis.setJson).toHaveBeenCalledWith(
-        config.endpointPath,
+        `${config.tenant_id}:${config.endpointPath}`,
         JSON.stringify({
           schema: config.schema,
           mapping: config.mapping,

--- a/tests/dems-engine/dems-engine.controller.spec.ts
+++ b/tests/dems-engine/dems-engine.controller.spec.ts
@@ -68,6 +68,7 @@ describe('DemsEngineController', () => {
       functions: { test: 'function' },
       related_transaction: '',
       publishing_status: 'active',
+      tenant_id: 'test-tenant',
     },
     publishing_status: 'active',
     trackedFields: {

--- a/tests/dems-engine/dems-engine.service.spec.ts
+++ b/tests/dems-engine/dems-engine.service.spec.ts
@@ -104,11 +104,12 @@ describe('DemsEngineService', () => {
   });
 
   describe('findSchemaAndMapping', () => {
+    const mockTenantId = 'tenant1';
     it('should return cached schema on cache hit (object format)', async () => {
       const cachedData = { schema: mockSchema, mapping: mockMapping, functions: mockFunctions };
       (mockRedisService.getJson as jest.Mock).mockResolvedValue(cachedData);
 
-      const result = await service.findSchemaAndMapping('/test');
+      const result = await service.findSchemaAndMapping('/test', mockTenantId);
 
       expect(result).toEqual([mockSchema, mockMapping, mockFunctions]);
       expect(mockLoggerService.log).toHaveBeenCalledWith('Cache hit for endpoint: /test');
@@ -118,7 +119,8 @@ describe('DemsEngineService', () => {
       const cachedString = JSON.stringify({ schema: mockSchema, mapping: mockMapping, functions: mockFunctions });
       (mockRedisService.getJson as jest.Mock).mockResolvedValue(cachedString);
 
-      const result = await service.findSchemaAndMapping('/test');
+      const mockTenantId = 'tenant1';
+      const result = await service.findSchemaAndMapping('/test', mockTenantId);
 
       expect(result).toEqual([mockSchema, mockMapping, mockFunctions]);
     });
@@ -131,7 +133,7 @@ describe('DemsEngineService', () => {
         ]),
       );
 
-      const result = await service.findSchemaAndMapping('/test');
+      const result = await service.findSchemaAndMapping('/test', mockTenantId);
 
       expect(mockLoggerService.error).toHaveBeenCalledWith(expect.stringContaining('Failed to parse cached schema'));
       expect(result).toEqual([mockSchema, mockMapping, mockFunctions, '']);
@@ -145,11 +147,11 @@ describe('DemsEngineService', () => {
         ]),
       );
 
-      const result = await service.findSchemaAndMapping('/test');
+      const result = await service.findSchemaAndMapping('/test', mockTenantId);
 
       expect(result).toEqual([mockSchema, mockMapping, mockFunctions, '']);
       expect(mockRedisService.setJson).toHaveBeenCalledWith(
-        '/test',
+        `${mockTenantId}:/test`,
         JSON.stringify({
           schema: mockSchema,
           mapping: mockMapping,
@@ -165,7 +167,7 @@ describe('DemsEngineService', () => {
       (mockRedisService.getJson as jest.Mock).mockResolvedValue(null);
       mockDatabaseService.query.mockResolvedValue(createMockQueryResult([]));
 
-      const result = await service.findSchemaAndMapping('/test');
+      const result = await service.findSchemaAndMapping('/test', mockTenantId);
 
       expect(result).toBeNull();
       expect(mockLoggerService.log).toHaveBeenCalledWith('No schema found for endpoint: /test');
@@ -175,7 +177,7 @@ describe('DemsEngineService', () => {
       (mockRedisService.getJson as jest.Mock).mockResolvedValue(null);
       mockDatabaseService.query.mockRejectedValue(new Error('Database connection failed'));
 
-      await expect(service.findSchemaAndMapping('/test')).rejects.toThrow('Database connection failed');
+      await expect(service.findSchemaAndMapping('/test', mockTenantId)).rejects.toThrow('Database connection failed');
     });
   });
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
--> the query logic to fetch config objects (schema, mapping etc) at startup, and at cache miss, did not include tenant-scoping. We included proper tenant-id scoping just like everywhere else in the codebase.

## Why are we doing this?
--> So that if two tenants have the same endpoint, it could be distinguished in the cache, just like it is differentiated in the DB.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done